### PR TITLE
Fixes footer settings url

### DIFF
--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -2,7 +2,7 @@
     <small class="text-gray-500">Copyright ©
         {{settings.name}}
         2020. Made with ❤ by
-        <a href="{{settings.meta.url}}" target="_blank" class="underline">{{settings.author}}</a>
+        <a href="{{settings.url}}" target="_blank" class="underline">{{settings.author}}</a>
         •
         <a href="https://github.com/surjithctly/neat-starter" class="underline" target="_blank" rel="noopener">View on Github</a>
     </small>


### PR DESCRIPTION
The [settings.yaml](https://github.com/surjithctly/neat-starter/blob/master/src/_data/settings.yaml#L4) data uses the `url` _key_ instead of `meta.url`.