### PR TITLE
Fixed links in second-post.md

### DIFF
--- a/src/posts/second-post.md
+++ b/src/posts/second-post.md
@@ -11,8 +11,8 @@ Leverage agile frameworks to provide a robust synopsis for high level overviews.
 
 ## Section Header
 
-<a href="{{ '/posts/firstpost/' | url }}">First post</a>
-<a href="{{ '/posts/thirdpost/' | url }}">Third post</a>
+<a href="{{ '/posts/my-first-post/' | url }}">First post</a>
+<a href="{{ '/posts/my-third-big-post/' | url }}">Third post</a>
 
 Bring to the table win-win survival strategies to ensure proactive domination. At the end of the day, going forward, a new normal that has evolved from generation X is on the runway heading towards a streamlined cloud solution. User generated content in real-time will have multiple touchpoints for offshoring.
 


### PR DESCRIPTION
The two links to the first and third blog posts had an incorrect filename in the url