### PR TITLE
Upgraded eleventy to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production postcss src/static/css/tailwind.css --o _site/static/css/style.css"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^0.11.0",
+    "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
     "@tailwindcss/typography": "^0.3.1",
     "alpinejs": "^2.6.0",


### PR DESCRIPTION
Upgraded eleventy to 0.12.1 to fix high severity vulnerability
Specifically has to do with pug, which can be fixed by by updating eleventy.