### PR TITLE
call browsersync explictly for simpler watching

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,12 +26,8 @@ module.exports = function (eleventyConfig) {
     yaml.safeLoad(contents)
   );
 
-  // Add Tailwind Output CSS as Watch Target
-  eleventyConfig.addWatchTarget("./_tmp/static/css/style.css");
-
   // Copy Static Files to /_Site
   eleventyConfig.addPassthroughCopy({
-    "./_tmp/static/css/style.css": "./static/css/style.css",
     "./src/admin/config.yml": "./admin/config.yml",
     "./node_modules/alpinejs/dist/alpine.js": "./static/js/alpine.js",
     "./node_modules/prismjs/themes/prism-tomorrow.css":

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "debug": "set DEBUG=* & eleventy",
     "css": "postcss src/static/css/tailwind.css --o _site/static/css/style.css --watch",
     "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production postcss src/static/css/tailwind.css --o _site/static/css/style.css",
-    "browsersync": "browser-sync start --server '_site' --files '_site' --port 8080"
+    "browsersync": "browser-sync start --server '_site' --files '_site' --port 8080 --no-notify --no-open"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
   "scripts": {
-    "start": "npm-run-all --parallel css eleventy",
-    "eleventy": "eleventy --serve",
+    "start": "npm-run-all --parallel css eleventy browsersync",
+    "eleventy": "eleventy --watch",
     "debug": "set DEBUG=* & eleventy",
-    "css": "postcss src/static/css/tailwind.css --o _tmp/static/css/style.css --watch",
-    "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production postcss src/static/css/tailwind.css --o _site/static/css/style.css"
+    "css": "postcss src/static/css/tailwind.css --o _site/static/css/style.css --watch",
+    "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production postcss src/static/css/tailwind.css --o _site/static/css/style.css",
+    "browsersync": "browser-sync start --server '_site' --files '_site' --port 8080"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
     "@tailwindcss/typography": "^0.3.1",
     "alpinejs": "^2.6.0",
+    "browser-sync": "^2.26.14",
     "cross-env": "^7.0.2",
     "cssnano": "^4.1.10",
     "html-minifier": "^4.0.0",


### PR DESCRIPTION
I have never been able to get passthrough and watch working correctly on Mac, so I moved to call BrowserSync explicitly rather than through Eleventy and simply build the PostCSS file as normal instead of using a tmp directory. This should provide more flexibility later rather than changing the 11ty config everytime you have a new static asset generated.