### PR TITLE
fix browsersync issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "debug": "set DEBUG=* & eleventy",
     "css": "postcss src/static/css/tailwind.css --o _site/static/css/style.css --watch",
     "build": "cross-env NODE_ENV=production eleventy && cross-env NODE_ENV=production tailwindcss -i src/static/css/tailwind.css -o _site/static/css/style.css",
-    "browsersync": "browser-sync start --server '_site' --files '_site' --port 8080 --no-notify --no-open"
+    "browsersync": "browser-sync start --server _site --files _site --port 8080 --no-notify --no-open"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",


### PR DESCRIPTION
Removed single quotes around _site folder in browser sync script to make compatible with Microsoft Windows environments.